### PR TITLE
2019 Summer update

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -13,12 +13,12 @@ General purpose applications for daily use.
 |[Google Chrome](https://www.google.com/chrome/)||
 |[Keybase](https://keybase.io/)|Key directory that maps social media identities to encryption keys in a publicly auditable manner. Keybase offers an end-to-end encrypted chat and cloud storage system.|
 |[ONLYOFFICE](https://www.onlyoffice.com/)|Office suite.|
+|[Notion](https://www.notion.so)|All-in-one workspace.|
 |[Quick Look Plugins](https://github.com/sindresorhus/quick-look-plugins)|Useful plugins for Quick Look for faster preview of non-natively supported file types. In this case, preview for Markdown files and files without extension is installed.|
 |[Rocket](https://matthewpalmer.net/rocket/)|Emoji on MacOS, Slack style. Just type `:` for a emoji picker to show up. |
 |[Slack](https://slack.com/)||
 |[Spectacle](https://www.spectacleapp.com)|App to help with window management based on keyboard shortcuts.|
 |[Spotify](https://www.spotify.com/)|Music streaming service that gives you access to millions of songs.|
-|[Typora](https://typora.io/)|Minimal markdown editor, providing new ways for reading and writing markdown.|
 |[VLC](https://www.videolan.org/vlc/)|Cross-platform multimedia player and framework that plays most multimedia files.|
 |[WhatsApp](https://www.whatsapp.com/)||
 

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -56,6 +56,7 @@ Tools to help boosting productivity within the Terminal.
 |[bat](https://github.com/sharkdp/bat)|A `cat` clone with syntax highlighting and Git integration.|
 |[csvkit](https://github.com/wireservice/csvkit)|A suite of utilities for converting to and working with CSV, the king of tabular file formats.|
 |[diff-so-fancy](https://github.com/so-fancy/diff-so-fancy)|`diff-so-fancy` strives to make your diffs human readable instead of machine readable. This helps improve code quality and help you spot defects faster.|
+|[dive](https://github.com/wagoodman/dive)|A tool for exploring each layer in a docker image.|
 |[fd](https://github.com/sharkdp/fd)|A simple, fast and user-friendly alternative to `find`.|
 |[fzf](https://github.com/junegunn/fzf)|`fzf` is a general-purpose command-line fuzzy finder.|
 |[htop](https://hisham.hm/htop/index.php)|Interactive process viewer for Unix systems.|

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -11,7 +11,6 @@ General purpose applications for daily use.
 |[1Password](https://1password.com/)|Password manager that provides a place for users to store various passwords, software licenses, and other sensitive information in a virtual vault that is locked with a PBKDF2-guarded master password.|
 |[Alfred](https://www.alfredapp.com/)|App for MacOS which boosts your efficiency with hotkeys, keywords, text expansion and more.|
 |[Google Chrome](https://www.google.com/chrome/)||
-|[Grammarly](https://www.grammarly.com/)|Grammar checking, spell checking, and plagiarism detection platform.|
 |[Keybase](https://keybase.io/)|Key directory that maps social media identities to encryption keys in a publicly auditable manner. Keybase offers an end-to-end encrypted chat and cloud storage system.|
 |[Quick Look Plugins](https://github.com/sindresorhus/quick-look-plugins)|Useful plugins for Quick Look for faster preview of non-natively supported file types. In this case, preview for Markdown files and files without extension is installed.|
 |[Rocket](https://matthewpalmer.net/rocket/)|Emoji on MacOS, Slack style. Just type `:` for a emoji picker to show up. |

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -12,6 +12,7 @@ General purpose applications for daily use.
 |[Alfred](https://www.alfredapp.com/)|App for MacOS which boosts your efficiency with hotkeys, keywords, text expansion and more.|
 |[Google Chrome](https://www.google.com/chrome/)||
 |[Keybase](https://keybase.io/)|Key directory that maps social media identities to encryption keys in a publicly auditable manner. Keybase offers an end-to-end encrypted chat and cloud storage system.|
+|[ONLYOFFICE](https://www.onlyoffice.com/)|Office suite.|
 |[Quick Look Plugins](https://github.com/sindresorhus/quick-look-plugins)|Useful plugins for Quick Look for faster preview of non-natively supported file types. In this case, preview for Markdown files and files without extension is installed.|
 |[Rocket](https://matthewpalmer.net/rocket/)|Emoji on MacOS, Slack style. Just type `:` for a emoji picker to show up. |
 |[Slack](https://slack.com/)||

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -87,7 +87,7 @@ Tools for Kotlin development.
 
 |||
 |-|-|
-|[Java](http://www.oracle.com/technetwork/java/javase/overview/index.html)|Java Standard Edition Development Kit.|
+|[Java](https://openjdk.java.net)|Java Standard Edition Development Kit.|
 |[kotlin](https://kotlinlang.org/)|Statically typed programming language for modern multiplatform applications.|
 |[IntelliJ](https://www.jetbrains.com/idea/)|IDE for developing Java-based software.|
 

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -65,9 +65,9 @@ Tools to help boosting productivity within the Terminal.
 |[ncdu](https://dev.yorhel.nl/ncdu)|`ncdu` is a disk usage analyzer with an ncurses interface.|
 |[noti](https://github.com/variadico/noti)|Tool that monitors a process and triggers a notification when done.|
 |[q](https://github.com/harelba/q)|`q` is a command line tool that allows direct execution of SQL-like queries on CSVs/TSVs (and any other tabular text files). It overlaps a bit with the functionalities provided by `csvkit`.|
-|[siege](https://github.com/JoeDog/siege)|HTTP load tester and benchmarking utility.|
 |[The Silver Searcher](https://github.com/ggreer/the_silver_searcher)|A code-searching tool similar to `ack`, but faster.|
 |[tldr](https://github.com/tldr-pages/tldr)|Simplified and community-driven man pages.|
+|[vegeta](https://github.com/tsenart/vegeta)|HTTP load testing tool and library.|
 |[unrar](https://www.rarlab.com/)|Utility to Extract, view, and test RAR archives.|
 
 ### Frontend Development

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -12,6 +12,7 @@ The following extensions are installed on VSCode using the script `scripts/10_vs
 
 |Extension|ID|Description|
 |:--------|:-|:----------|
+|Code Runner|`formulahendry.code-runner`|Run code snippet or code file for multiple languages.|
 |Code Spell Checker|`streetsidesoftware.code-spell-checker`|Spelling checker for source code.|
 |Debugger for Chrome|`msjsdiag.debugger-for-chrome`|Debug your JavaScript code in the Chrome browser, or any other target that supports the Chrome Debugger protocol.|
 |Docker|`ms-azuretools.vscode-docker`|Adds syntax highlighting, commands, hover tips, and linting for Dockerfile and docker-compose files.|

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -19,6 +19,7 @@ The following extensions are installed on VSCode using the script `scripts/10_vs
 |ESLint|`dbaeumer.vscode-eslint`|Integrates ESLint JavaScript into VS Code.|
 |GitLens|`eamodio.gitlens`|Supercharge the Git capabilities built into Visual Studio Code.|
 |Jest|`orta.vscode-jest`|Use Facebook's Jest With Pleasure.|
+|Kotlin|`mathiasfrohlich.Kotlin`| Syntax support for the Kotlin programming language.|
 |Markdown All in One|`yzhang.markdown-all-in-one`|All you need to write Markdown (keyboard shortcuts, table of contents, auto preview and more).|
 |Path Intellisense|`christian-kohler.path-intellisense`|Visual Studio Code plugin that autocompletes filenames.|
 |Prettier|`esbenp.prettier-vscode`|VS Code plugin for prettier/prettier.|

--- a/scripts/10_vscode.sh
+++ b/scripts/10_vscode.sh
@@ -28,8 +28,6 @@ echo "- Prettify JSON"
 code --install-extension mohsen1.prettify-json
 echo "- Project Manager"
 code --install-extension alefragnani.project-manager
-echo "- Ruby"
-code --install-extension rebornix.ruby
 echo "- TSLint"
 code --install-extension ms-vscode.vscode-typescript-tslint-plugin
 

--- a/scripts/10_vscode.sh
+++ b/scripts/10_vscode.sh
@@ -4,6 +4,8 @@ echo "Installing VSCode configuration..."
 
 ## Extensions
 echo "\nInstalling Extensions..."
+echo "- Code Runner"
+code --install-extension formulahendry.code-runner
 echo "- Code Spell Checker"
 code --install-extension streetsidesoftware.code-spell-checker
 echo "- Debugger for Chrome"

--- a/scripts/1_general.sh
+++ b/scripts/1_general.sh
@@ -14,6 +14,9 @@ install cask google-chrome
 print_start cask keybase
 install cask keybase
 
+print_start cask onlyoffice
+install cask onlyoffice
+
 print_start cask rocket
 install cask rocket
 

--- a/scripts/1_general.sh
+++ b/scripts/1_general.sh
@@ -17,6 +17,9 @@ install cask keybase
 print_start cask onlyoffice
 install cask onlyoffice
 
+print_start cask notion
+install cask notion
+
 print_start cask rocket
 install cask rocket
 
@@ -31,9 +34,6 @@ install cask spectacle
 
 print_start cask spotify
 install cask spotify
-
-print_start cask typora
-install cask typora
 
 print_start cask vlc
 install cask vlc

--- a/scripts/1_general.sh
+++ b/scripts/1_general.sh
@@ -11,9 +11,6 @@ install cask alfred
 print_start cask google-chrome
 install cask google-chrome
 
-print_start cask grammarly
-install cask grammarly
-
 print_start cask keybase
 install cask keybase
 

--- a/scripts/5_terminal_tools.sh
+++ b/scripts/5_terminal_tools.sh
@@ -38,14 +38,14 @@ install noti
 print_start q
 install q
 
-print_start siege
-install siege
-
 print_start the_silver_searcher
 install the_silver_searcher
 
 print_start tldr
 install tldr
+
+print_start vegeta
+install vegeta
 
 print_start unrar
 install unrar

--- a/scripts/5_terminal_tools.sh
+++ b/scripts/5_terminal_tools.sh
@@ -14,6 +14,9 @@ install csvkit
 print_start diff-so-fancy
 install diff-so-fancy
 
+print_start dive
+install dive
+
 print_start fd
 install fd
 

--- a/scripts/7_dev_kotlin.sh
+++ b/scripts/7_dev_kotlin.sh
@@ -12,3 +12,6 @@ install kotlin
 
 print_start cask intellij-idea-ce
 install cask intellij-idea-ce
+
+echo "Installing Kotlin extension in VSCode"
+code --install-extension mathiasfrohlich.Kotlin

--- a/scripts/8_dev_ruby.sh
+++ b/scripts/8_dev_ruby.sh
@@ -7,3 +7,6 @@ install chruby
 
 print_start ruby-install
 install ruby-install
+
+echo "Installing Ruby extension in VSCode"
+code --install-extension rebornix.ruby


### PR DESCRIPTION
**Added**
* ONLYOFFICE
* Notion
* dive
* vegeta
* VSCode Extension: Code Runner
* VSCode Extension: Kotlin

**Removed**
* Grammarly
* Typora
* Siege

**Moved**
* VSCode Extension: Ruby is now installed when setting up Ruby env

**Fixes**
* Point to OpenJDK's site instead of Oracle's.